### PR TITLE
You can no longer open two instances at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@
 **/*.rs.bk
 HotelBookingAPI/HotelBookingAPI/obj/Debug/net8.0/HotelBookingAPI.AssemblyInfo.cs
 HotelBookingAPI/HotelBookingAPI/obj/Debug/net8.0/HotelBookingAPI.AssemblyInfoInputs.cache
+HotelBookingAPI/HotelBookingAPI/obj/HotelBookingAPI.csproj.nuget.dgspec.json
+HotelBookingAPI/HotelBookingAPI/obj/project.assets.json
+HotelBookingAPI/HotelBookingAPI/obj/project.nuget.cache
+HotelBookingAPI/HotelBookingAPI/obj/Debug/net8.0/HotelBookingAPI.AssemblyInfo.cs
+HotelBookingAPI/HotelBookingAPI/obj/Debug/net8.0/HotelBookingAPI.AssemblyInfoInputs.cache

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use rodio::{Decoder, OutputStream, Sink};
 
 use std::error::Error;
 use std::io::Read;
+use std::process::Command;
 // use std::thread::spawn;
 use curl::easy::Easy;
 use curl::easy::List;
@@ -30,6 +31,11 @@ slint::include_modules!();
 
 fn main() -> Result<(), Box<dyn Error>> {
     let lock = Arc::new(Mutex::new(AtomicBool::new(true)));
+    if(!fs::metadata("/tmp/enamy/lock").is_err()){
+        Command::new("kdialog").arg("--error").arg("EnAmy is already running").arg("--title").arg("EAEH").status().unwrap();
+        std::process::exit(69420);
+    }
+    let mut _soft_lock = BufWriter::new(File::create("/tmp/enamy/lock").unwrap());
     let input_active = Arc::new(Mutex::new(AtomicBool::new(true)));
     let mut delay: i32 = 0;
     let site = "http://192.168.122.193:5000/api/HotelBooking/CreateVoice";
@@ -166,6 +172,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
+    Command::new("rm").arg("/tmp/enamy/lock").status().unwrap();
     Ok(())
 }
 


### PR DESCRIPTION
Added a lock file in `/tmp/enamy/lock`, before launching it checks that that path does not exist, if it exists, it notifies the user that another instance is already open, if it does NOT exist, it will create one and continue as per usual